### PR TITLE
Fix NioDatagramChannel constructor error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 
 COPY --from=builder /app/graleph.jar .
 
+COPY reflect.json ./reflect.json
 COPY ./script/compile /app/compile
 
 RUN /app/compile

--- a/reflect.json
+++ b/reflect.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name" : "io.netty.channel.socket.nio.NioDatagramChannel",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+  }
+]

--- a/script/compile
+++ b/script/compile
@@ -5,6 +5,7 @@ native-image  \
   --no-server \
   --no-fallback \
   -H:+ReportExceptionStackTraces \
+  -H:ReflectionConfigurationFiles=reflect.json \
   --initialize-at-build-time \
   --initialize-at-run-time=io.netty.channel.epoll.EpollEventArray,io.netty.channel.unix.Errors,io.netty.channel.unix.IovArray,io.netty.channel.unix.Socket,io.netty.channel.epoll.Native,io.netty.channel.epoll.EpollEventLoop,io.netty.util.internal.logging.Log4JLogger \
   --allow-incomplete-classpath \

--- a/src/graleph/core.clj
+++ b/src/graleph/core.clj
@@ -8,6 +8,7 @@
     [manifold.stream :as s]
     [utility-belt.lifecycle :as lifecycle]))
 
+(set! *warn-on-reflection* true)
 
 ;; Adopted from aleph.udp examples
 (defn parse-statsd-packet


### PR DESCRIPTION
* added a reflection config as recommended by @borkdude on slack
* turned on reflection warnings just to be safe

By the way, is there any particular reason you were using `docker.pkg.github.com/graalvm/container/community:latest` instead of `oracle/graalvm-ce:latest` though? (I couldn't pull the former)